### PR TITLE
Explicitly add oauth gem

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -12,6 +12,8 @@ gem 'rails', '~> 6.0.2'
 gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 4.3'
+
+gem 'oauth'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 6.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/template/Gemfile.lock
+++ b/template/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
     public_suffix (4.0.1)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -208,6 +209,7 @@ DEPENDENCIES
   jbuilder (~> 2.10)
   jquery-rails
   listen (~> 3.2.1)
+  oauth
   puma (~> 4.3)
   rails (~> 6.0.2)
   sass-rails (~> 6.0)
@@ -220,4 +222,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.13.7
+   1.17.2

--- a/template/config/initializers/new_framework_defaults.rb
+++ b/template/config/initializers/new_framework_defaults.rb
@@ -17,8 +17,5 @@ ActiveSupport.to_time_preserves_timezone = true
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
### Change

Included oauth gem in gemfile, to resolve the dependency of requiring `'oauth/request_proxy/action_controller_request'` in application_controller.rb

### Why?

Application fails to launch if "oauth" gem is not included.